### PR TITLE
Switch setup-ruby to latest

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           submodules: true
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1 # latest
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
Our Github Actions are borked.
https://github.com/ruby/setup-ruby/issues/595 suggests, using the v1 tag to follow latest relase, with Dependabot.