### PR TITLE
Removed mention of google group on links page.

### DIFF
--- a/links.html
+++ b/links.html
@@ -16,11 +16,7 @@ title: Links
   </tr>
   <tr>
     <td><a href='https://discord.gg/hkv2zPS'> Discord </a></td>
-    <td> Dette er vores primære kommunikationsplatform. Vi anbefaler, at alle medlemmer joiner. </td>
-  </tr>
-  <tr>
-    <td><a href='https://groups.google.com/forum/#!forum/openspaceaarhus'> Google Group </a></td>
-    <td> Vores officielle kommunikationsplatform til de vigtigste beskeder. Vi anbefaler, at alle medlemmer subscriber til denne mailing list. </td>
+    <td> Vores officielle kommunikationsplatform. Det er den nemmeste måde at komme i kontakt med foreningen på. Vi anbefaler, at alle medlemmer joiner. </td>
   </tr>
   <tr>
     <td>


### PR DESCRIPTION
Removed mention of google group on links page. to align with changes voted in during general assembly. 
google group is still linked on OSAA wiki and thus still available. Also changed wording around the discord slightly.